### PR TITLE
Check if el.width and el.height are number and put them into data when deserializing

### DIFF
--- a/packages/slate-editor-html/src/imageRules.js
+++ b/packages/slate-editor-html/src/imageRules.js
@@ -44,6 +44,14 @@ export default function(inlineType = IMAGE, stylesAttr = defaultAttrs) {
           data.height = el.style.height;
         }
 
+        if (typeof el.width === 'number') {
+          data.width = el.width;
+        }
+
+        if (typeof el.height === 'number') {
+          data.height = el.height;
+        }
+
         return {
           object: 'inline',
           type: inlineType,

--- a/packages/slate-editor-html/src/imageRules.js
+++ b/packages/slate-editor-html/src/imageRules.js
@@ -44,11 +44,11 @@ export default function(inlineType = IMAGE, stylesAttr = defaultAttrs) {
           data.height = el.style.height;
         }
 
-        if (typeof el.width === 'number') {
+        if (typeof el.width === 'number' && el.width > 0) {
           data.width = el.width;
         }
 
-        if (typeof el.height === 'number') {
+        if (typeof el.height === 'number' && el.height > 0) {
           data.height = el.height;
         }
 


### PR DESCRIPTION
Fix #64 by checking for `el.width` and `el.height`.

