### PR TITLE
ref #66: fix row and column number for slate-icon-table

### DIFF
--- a/packages/slate-icon-table/src/index.js
+++ b/packages/slate-icon-table/src/index.js
@@ -43,8 +43,8 @@ export default class Table extends React.Component<IconProps> {
     onChange(
       this.editTable.changes.insertTable(
         change,
-        data.columnNumber,
-        data.rowNumber
+        data.columnNumber+1,
+        data.rowNumber+1
       )
     );
   }


### PR DESCRIPTION
fix for https://github.com/Canner/slate-editor-icons/issues/66